### PR TITLE
Remove extraneous require 'faker'

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,4 @@
 require 'bcrypt'
-require 'faker'
 
 class User < ActiveRecord::Base
   include BCrypt


### PR DESCRIPTION
There was `require 'faker'` line in the user model for no reason I could see, the heroku logs were barfing on that.
